### PR TITLE
[RFC] Add support for UFFD backed memory when restoring Firecracker VM from snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,10 +388,16 @@ dependencies = [
  "event-manager",
  "libc",
  "logger",
+ "micro_http",
  "mmds",
+ "nix 0.23.0",
+ "regex",
  "seccompiler",
+ "serde",
+ "serde_json",
  "snapshot",
  "timerfd",
+ "userfaultfd",
  "utils",
  "vmm",
 ]
@@ -508,9 +514,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "libloading"
@@ -607,6 +613,19 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "void",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1092,7 +1111,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
- "nix",
+ "nix 0.17.0",
  "thiserror",
  "userfaultfd-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -74,6 +74,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453c49e5950bb0eb63bb3df640e31618846c89d5b7faa54040d76e98e0134375"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,10 +114,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bstr"
-version = "0.2.16"
+name = "bitvec"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -128,10 +159,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+
+[[package]]
+name = "cexpr"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -201,7 +264,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -211,7 +274,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -222,7 +285,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -235,7 +298,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -340,15 +403,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "half"
@@ -426,10 +501,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
+
+[[package]]
+name = "libloading"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi",
+]
 
 [[package]]
 name = "linux-loader"
@@ -446,7 +537,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -464,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
@@ -506,6 +597,31 @@ name = "net_gen"
 version = "0.1.0"
 
 [[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+ "void",
+]
+
+[[package]]
+name = "nom"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+dependencies = [
+ "bitvec",
+ "funty",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +645,12 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "plotters"
@@ -613,6 +735,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -712,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -741,6 +869,12 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -843,6 +977,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
 name = "snapshot"
 version = "0.1.0"
 dependencies = [
@@ -864,12 +1004,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "rand",
  "redox_syscall",
@@ -884,6 +1030,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -918,6 +1084,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "userfaultfd"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3305eb184fac679845224d58e32023cc5f63007135347b39d9e02ff0a00b5e"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "libc",
+ "nix",
+ "thiserror",
+ "userfaultfd-sys",
+]
+
+[[package]]
+name = "userfaultfd-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04ee739156569105b2203aa22feabf08d14f2e1fab2fb42af2420f1c811cd20"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cfg-if 0.1.10",
+]
+
+[[package]]
 name = "utils"
 version = "0.1.0"
 dependencies = [
@@ -927,6 +1118,12 @@ dependencies = [
  "serde_json",
  "vmm-sys-util",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "versionize"
@@ -1012,6 +1209,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snapshot",
+ "userfaultfd",
  "utils",
  "versionize",
  "versionize_derive",
@@ -1029,6 +1227,12 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wait-timeout"
@@ -1062,7 +1266,7 @@ version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -1150,3 +1354,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/src/api_server/src/request/snapshot.rs
+++ b/src/api_server/src/request/snapshot.rs
@@ -107,7 +107,8 @@ mod tests {
 
         let mut expected_cfg = LoadSnapshotParams {
             snapshot_path: PathBuf::from("foo"),
-            mem_file_path: PathBuf::from("bar"),
+            mem_backend_type: Default::default(),
+            mem_backend_path: PathBuf::from("bar"),
             enable_diff_snapshots: false,
             resume_vm: false,
         };
@@ -125,7 +126,8 @@ mod tests {
 
         expected_cfg = LoadSnapshotParams {
             snapshot_path: PathBuf::from("foo"),
-            mem_file_path: PathBuf::from("bar"),
+            mem_backend_type: Default::default(),
+            mem_backend_path: PathBuf::from("bar"),
             enable_diff_snapshots: true,
             resume_vm: false,
         };
@@ -144,7 +146,8 @@ mod tests {
 
         expected_cfg = LoadSnapshotParams {
             snapshot_path: PathBuf::from("foo"),
-            mem_file_path: PathBuf::from("bar"),
+            mem_backend_type: Default::default(),
+            mem_backend_path: PathBuf::from("bar"),
             enable_diff_snapshots: false,
             resume_vm: true,
         };

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -1045,16 +1045,24 @@ definitions:
   SnapshotLoadParams:
     type: object
     required:
-      - mem_file_path
+      - mem_backend_path
       - snapshot_path
     properties:
       enable_diff_snapshots:
         type: boolean
         description:
           Enable support for incremental (diff) snapshots by tracking dirty guest pages.
-      mem_file_path:
+      mem_backend_type:
         type: string
-        description: Path to the file that contains the guest memory to be loaded.
+        enum:
+          - File
+          - UffdOverUDS
+      mem_backend_path:
+        type: string
+        description: Based on 'mem_backend_type' it is either
+        1) Path to the file that contains the guest memory to be loaded,
+        2) Path to the UDS where a custom page-fault handler process is listening
+        for the UFFD set up by Firecracker to handle its guest memory page faults.
       snapshot_path:
         type: string
         description: Path to the file that contains the microVM state to be loaded.

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -20,3 +20,11 @@ seccompiler = { path = "../seccompiler" }
 snapshot = { path = "../snapshot"}
 utils = { path = "../utils" }
 vmm = { path = "../vmm" }
+
+[dev-dependencies]
+nix = "0.23.0"
+regex = ">=1.0.0"
+serde = { version = ">=1.0.27", features = ["derive"] }
+serde_json = ">=1.0.9"
+userfaultfd = ">=0.4.0"
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "36e59a0" }

--- a/src/firecracker/examples/uffd_handler/main.rs
+++ b/src/firecracker/examples/uffd_handler/main.rs
@@ -1,0 +1,71 @@
+mod uffd_handler;
+
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Barrier};
+
+fn firecracker_api_call(stream: &mut UnixStream, method_and_uri: &str, body: &str) {
+    let request = format!(
+        "{} HTTP/1.1\r\n\
+         Content-Length: {}\r\n\
+         Content-Type: application/json\r\n\r\n\
+         {}",
+        method_and_uri,
+        body.len(),
+        body
+    );
+    println!("API request:\n{}", request);
+    stream
+        .write_all(request.as_bytes())
+        .expect("cannot send API request");
+
+    let mut response = vec![0u8; 1024];
+    let bytes_read = stream
+        .read(&mut response[..])
+        .expect("cannot read API response");
+    response.resize(bytes_read, 0);
+    println!(
+        "API response of {} bytes:\n{}",
+        bytes_read,
+        String::from_utf8(response).unwrap()
+    );
+}
+
+fn main() {
+    println!("Connecting to Firecracker API.");
+
+    // TODO: make paths configurable thru cmdline params.
+    let snapshot_path = "./foo.image";
+    let mem_file_path = "/tmp/foo.mem";
+    let path_to_api_socket = "/tmp/firecracker-sb0.sock";
+    let path_to_uffd_socket = "/tmp/firecracker-sb0-uffd.sock";
+
+    let mut socket = UnixStream::connect(path_to_api_socket).expect("cannot connect");
+
+    let barrier = Arc::new(Barrier::new(2));
+    let uffd_sock_path = path_to_uffd_socket.to_string();
+    let mem_fpath = mem_file_path.to_string();
+    let uds_barrier = barrier.clone();
+
+    let handle =
+        std::thread::spawn(move || uffd_handler::run(uffd_sock_path, mem_fpath, uds_barrier));
+    // Wait for uffd thread to start listening on uffd UDS before sending API call to fc.
+    barrier.wait();
+    println!("Sending Load Snap API call.");
+
+    let body = format!(
+        "\
+        {{\
+            \"snapshot_path\":\"{}\",\
+            \"mem_backend_type\":\"UffdOverUDS\",\
+            \"mem_backend_path\":\"{}\"\
+        }}",
+        snapshot_path, path_to_uffd_socket
+    );
+    firecracker_api_call(&mut socket, "PUT /snapshot/load", &body);
+
+    println!("Sending Resume-VM API call.");
+    firecracker_api_call(&mut socket, "PATCH /vm", "{\"state\":\"Resumed\"}");
+
+    handle.join().expect("uffd thread crashed");
+}

--- a/src/firecracker/examples/uffd_handler/uffd_handler.rs
+++ b/src/firecracker/examples/uffd_handler/uffd_handler.rs
@@ -1,0 +1,166 @@
+use libc::c_void;
+use nix::poll::{poll, PollFd, PollFlags};
+use nix::sys::mman::{mmap, MapFlags, ProtFlags};
+use nix::unistd::{sysconf, SysconfVar};
+use serde::Deserialize;
+use std::fs::File;
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::ptr;
+use std::sync::{Arc, Barrier};
+use userfaultfd::Uffd;
+use utils::sock_ctrl_msg::ScmSocket;
+
+// copy/pasted from firecracker vmm
+mod firecracker_imports {
+    use super::Deserialize;
+    /// This describes the mapping between Firecracker base virtual address and offset in the
+    /// buffer or file backend for a guest memory region. It is used to tell an external
+    /// process/thread where to populate the guest memory data for this range.
+    ///
+    /// E.g. Guest memory contents for a region of `size` bytes can be found in the backend
+    /// at `offset` bytes from the beginning, and should be copied/populated into `base_host_address`.
+    #[derive(Clone, Debug, Default, Deserialize)]
+    pub struct RegionBackendMapping {
+        /// Base host virtual address where the guest memory contents for this region
+        /// should be copied/populated.
+        pub base_h_va: u64,
+        /// Region size.
+        pub size: usize,
+        /// Offset in the backend file/buffer where the region contents are.
+        pub offset: u64,
+    }
+}
+use firecracker_imports::RegionBackendMapping;
+
+struct UffdPfHandler {
+    mappings: Vec<RegionBackendMapping>,
+    backing_buffer: *const u8,
+    uffd: Uffd,
+}
+
+impl UffdPfHandler {
+    pub fn from_unix_stream(stream: UnixStream, data: *const u8, size: usize) -> Self {
+        let mut message_buf = vec![0u8; 1024];
+        let (bytes_read, file) = stream
+            .recv_with_fd(&mut message_buf[..])
+            .expect("cannot recv_with_fd");
+        message_buf.resize(bytes_read, 0);
+
+        let body = String::from_utf8(message_buf).unwrap();
+        println!("API response of {} bytes:\n{:?}", bytes_read, body);
+        let file = file.expect("Uffd not passed through UDS!");
+
+        let mappings =
+            serde_json::from_str::<Vec<RegionBackendMapping>>(&body).expect("deser failed");
+        let memsize: usize = mappings.iter().map(|r| r.size).sum();
+        // Make sure memory size matches backing data size.
+        assert_eq!(memsize, size);
+
+        let uffd = unsafe { Uffd::from_raw_fd(file.into_raw_fd()) };
+        Self {
+            mappings,
+            backing_buffer: data,
+            uffd,
+        }
+    }
+
+    fn serve_pf(&self, addr: *mut u8, page_size: usize) {
+        let dst = (addr as usize & !(page_size as usize - 1)) as *mut c_void;
+        println!(
+            "    looking for file offset corresponding to hVA dst: {:?}",
+            dst
+        );
+
+        let mut found_mapping = None;
+        for r in self.mappings.iter() {
+            let fault_page_addr = dst as u64;
+            if r.base_h_va <= fault_page_addr && fault_page_addr < r.base_h_va + r.size as u64 {
+                found_mapping = Some(r.clone());
+            }
+        }
+
+        if let Some(r) = &found_mapping {
+            println!("    found it in: {:?}", r);
+        } else {
+            panic!("could not find addr within region mappings");
+        }
+
+        let r = found_mapping.unwrap();
+        let src = self.backing_buffer as u64 + r.offset;
+        // Populate whole region from backing mem-file.
+        let copy = unsafe {
+            self.uffd
+                .copy(src as *const _, r.base_h_va as *mut _, r.size, true)
+                .expect("uffd copy")
+        };
+        println!("        (uffdio_copy.copy returned {})", copy);
+    }
+
+    fn run_loop(&self) {
+        let page_size = sysconf(SysconfVar::PAGE_SIZE).unwrap().unwrap() as usize;
+        let pollfd = PollFd::new(self.uffd.as_raw_fd(), PollFlags::POLLIN);
+        println!("\nfault_handler_thread():");
+
+        // Loop, handling incoming events on the userfaultfd file descriptor
+        loop {
+            println!("    waiting for PFs...");
+            // See what poll() tells us about the userfaultfd
+            let nready = poll(&mut [pollfd], -1).expect("poll");
+
+            let revents = pollfd.revents().unwrap();
+            println!(
+                "    poll() returns: nready = {}; POLLIN = {}; POLLERR = {}",
+                nready,
+                revents.contains(PollFlags::POLLIN),
+                revents.contains(PollFlags::POLLERR),
+            );
+
+            // Read an event from the userfaultfd
+            let event = self
+                .uffd
+                .read_event()
+                .expect("read uffd_msg")
+                .expect("uffd_msg ready");
+
+            // We expect only one kind of event; verify that assumption
+            if let userfaultfd::Event::Pagefault { addr, .. } = event {
+                // Display info about the page-fault event
+                println!("    UFFD_EVENT_PAGEFAULT event: {:?}", event);
+                self.serve_pf(addr as *mut u8, page_size);
+            } else {
+                panic!("Unexpected event on userfaultfd");
+            }
+        }
+    }
+}
+
+pub fn run(uffd_sock_path: String, mem_file_path: String, barrier: Arc<Barrier>) {
+    let file = File::open(mem_file_path).expect("cannot open memfile");
+    let size = file.metadata().unwrap().len() as usize;
+    // Create a page that will be copied into the faulting region
+    let memfile_buffer = unsafe {
+        mmap(
+            ptr::null_mut(),
+            size,
+            ProtFlags::PROT_READ,
+            MapFlags::MAP_PRIVATE,
+            file.as_raw_fd(),
+            0,
+        )
+        .expect("mmap")
+    } as *const u8;
+
+    // Get Uffd from UDS. We'll use the uffd to handle PFs for Firecracker.
+    let listener = UnixListener::bind(&uffd_sock_path).expect("cannot bind");
+
+    println!("Bound UDS at: {:?}", uffd_sock_path);
+    // Signal main thread we're ready and listening on uffd UDS.
+    barrier.wait();
+
+    let (stream, _) = listener.accept().expect("cannot listen");
+    let uffd_handler = UffdPfHandler::from_unix_stream(stream, memfile_buffer, size);
+
+    uffd_handler.run_loop();
+    println!("Uffd thread done!");
+}

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -6,7 +6,7 @@
 // More specifically, we are re-exporting modules from `vmm_sys_util` as part
 // of the `utils` crate.
 pub use vmm_sys_util::{
-    epoll, errno, eventfd, fam, ioctl, rand, syscall, tempdir, tempfile, terminal,
+    epoll, errno, eventfd, fam, ioctl, rand, sock_ctrl_msg, syscall, tempdir, tempfile, terminal,
 };
 pub use vmm_sys_util::{ioctl_expr, ioctl_ioc_nr, ioctl_iow_nr};
 

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -12,6 +12,7 @@ vm-superio = ">=0.4.0"
 linux-loader = ">=0.4.0"
 serde = { version = ">=1.0.27", features = ["derive"] }
 serde_json = ">=1.0.9"
+userfaultfd = ">=0.4.0"
 versionize = ">=0.1.6"
 versionize_derive = ">=0.1.3"
 

--- a/src/vmm/src/memory_snapshot.rs
+++ b/src/vmm/src/memory_snapshot.rs
@@ -7,6 +7,8 @@ use std::fmt::{Display, Formatter};
 use std::fs::File;
 use std::io::SeekFrom;
 
+use crate::DirtyBitmap;
+use utils::{errno, get_page_size};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use vm_memory::{
@@ -14,14 +16,13 @@ use vm_memory::{
     GuestMemoryRegion, MemoryRegionAddress,
 };
 
-use crate::DirtyBitmap;
-use utils::{errno, get_page_size};
-
 /// State of a guest memory region saved to file/buffer.
 #[derive(Debug, PartialEq, Versionize)]
 // NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct GuestMemoryRegionState {
-    /// Base address.
+    // This should have been named `base_guest_addr` since it's _guest_ addr, but for
+    // backward compatibility we have to keep this name. At least this comment should help.
+    /// Base GuestAddress.
     pub base_address: u64,
     /// Region size.
     pub size: usize,
@@ -29,7 +30,7 @@ pub struct GuestMemoryRegionState {
     pub offset: u64,
 }
 
-/// Guest memory state.
+/// Describes guest memory regions and their snapshot file mappings.
 #[derive(Debug, Default, PartialEq, Versionize)]
 // NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct GuestMemoryState {
@@ -55,7 +56,7 @@ where
     /// Creates a GuestMemoryMmap given a `file` containing the data
     /// and a `state` containing mapping information.
     fn restore(
-        file: &File,
+        file: Option<&File>,
         state: &GuestMemoryState,
         track_dirty_pages: bool,
     ) -> std::result::Result<Self, Error>;
@@ -176,10 +177,10 @@ impl SnapshotMemory for GuestMemoryMmap {
             .map_err(Error::WriteMemory)
     }
 
-    /// Creates a GuestMemoryMmap given a `file` containing the data
-    /// and a `state` containing mapping information.
+    /// Creates a GuestMemoryMmap backed by a `file` if present, otherwise backed
+    /// by anonymous memory. Memory layout and ranges are described in `state` param.
     fn restore(
-        file: &File,
+        file: Option<&File>,
         state: &GuestMemoryState,
         track_dirty_pages: bool,
     ) -> std::result::Result<Self, Error> {
@@ -189,7 +190,7 @@ impl SnapshotMemory for GuestMemoryMmap {
                 .iter()
                 .map(|r| {
                     (
-                        Some(FileOffset::new(file.try_clone().unwrap(), r.offset)),
+                        file.map(|f| FileOffset::new(f.try_clone().unwrap(), r.offset)),
                         GuestAddress(r.base_address),
                         r.size,
                     )
@@ -302,7 +303,8 @@ mod tests {
             guest_memory.dump(&mut memory_file.as_file()).unwrap();
 
             let restored_guest_memory =
-                GuestMemoryMmap::restore(&memory_file.as_file(), &memory_state, false).unwrap();
+                GuestMemoryMmap::restore(Some(memory_file.as_file()), &memory_state, false)
+                    .unwrap();
 
             // Check that the region contents are the same.
             let mut actual_region = vec![0u8; page_size * 2];
@@ -336,7 +338,7 @@ mod tests {
 
             // We can restore from this because this is the first dirty dump.
             let restored_guest_memory =
-                GuestMemoryMmap::restore(&file.as_file(), &memory_state, false).unwrap();
+                GuestMemoryMmap::restore(Some(file.as_file()), &memory_state, false).unwrap();
 
             // Check that the region contents are the same.
             let mut actual_region = vec![0u8; page_size * 2];

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -13,7 +13,9 @@ use crate::builder::{self, StartMicrovmError};
 use crate::device_manager::persist::Error as DevicePersistError;
 use crate::mem_size_mib;
 use crate::vmm_config::machine_config::MAX_SUPPORTED_VCPUS;
-use crate::vmm_config::snapshot::{CreateSnapshotParams, LoadSnapshotParams, SnapshotType};
+use crate::vmm_config::snapshot::{
+    CreateSnapshotParams, LoadSnapshotParams, MemBackendType, SnapshotType,
+};
 use crate::vstate::{self, vcpu::VcpuState, vm::VmState};
 
 use crate::device_manager::persist::DeviceStates;
@@ -441,17 +443,22 @@ pub fn restore_from_snapshot(
     version_map: VersionMap,
 ) -> std::result::Result<Arc<Mutex<Vmm>>, LoadSnapshotError> {
     use self::LoadSnapshotError::*;
-    let track_dirty_pages = params.enable_diff_snapshots;
     let microvm_state = snapshot_state_from_file(&params.snapshot_path, version_map)?;
 
     // Some sanity checks before building the microvm.
     snapshot_state_sanity_check(&microvm_state)?;
 
-    let guest_memory = guest_memory_from_file(
-        &params.mem_file_path,
-        &microvm_state.memory_state,
-        track_dirty_pages,
-    )?;
+    let mem_backend_path = &params.mem_backend_path;
+    let mem_state = &microvm_state.memory_state;
+    let track_dirty_pages = params.enable_diff_snapshots;
+    let guest_memory = match params.mem_backend_type {
+        MemBackendType::File => {
+            guest_memory_from_file(mem_backend_path, mem_state, track_dirty_pages)
+        }
+        MemBackendType::UffdOverUDS => {
+            guest_memory_from_uffd(mem_backend_path, mem_state, track_dirty_pages)
+        }
+    }?;
     builder::build_microvm_from_snapshot(
         instance_info,
         event_manager,
@@ -485,6 +492,14 @@ fn guest_memory_from_file(
     let mem_file = File::open(mem_file_path).map_err(MemoryBackingFile)?;
     GuestMemoryMmap::restore(Some(&mem_file), mem_state, track_dirty_pages)
         .map_err(DeserializeMemory)
+}
+
+fn guest_memory_from_uffd(
+    _mem_file_path: &Path,
+    _mem_state: &GuestMemoryState,
+    _track_dirty_pages: bool,
+) -> std::result::Result<GuestMemoryMmap, LoadSnapshotError> {
+    unimplemented!()
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -483,7 +483,8 @@ fn guest_memory_from_file(
 ) -> std::result::Result<GuestMemoryMmap, LoadSnapshotError> {
     use self::LoadSnapshotError::{DeserializeMemory, MemoryBackingFile};
     let mem_file = File::open(mem_file_path).map_err(MemoryBackingFile)?;
-    GuestMemoryMmap::restore(&mem_file, mem_state, track_dirty_pages).map_err(DeserializeMemory)
+    GuestMemoryMmap::restore(Some(&mem_file), mem_state, track_dirty_pages)
+        .map_err(DeserializeMemory)
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -206,10 +206,10 @@ pub enum VmmData {
     Empty,
     /// The complete microVM configuration in JSON format.
     FullVmConfig(VmmConfig),
-    /// The microVM configuration represented by `VmConfig`.
-    MachineConfiguration(VmConfig),
     /// The microVM instance information.
     InstanceInformation(InstanceInfo),
+    /// The microVM configuration represented by `VmConfig`.
+    MachineConfiguration(VmConfig),
 }
 
 /// Shorthand result type for external VMM commands.
@@ -1214,7 +1214,8 @@ mod tests {
         // Without resume.
         let req = VmmAction::LoadSnapshot(LoadSnapshotParams {
             snapshot_path: PathBuf::new(),
-            mem_file_path: PathBuf::new(),
+            mem_backend_type: Default::default(),
+            mem_backend_path: PathBuf::new(),
             enable_diff_snapshots: false,
             resume_vm: false,
         });
@@ -1227,7 +1228,8 @@ mod tests {
         // With resume.
         let req = VmmAction::LoadSnapshot(LoadSnapshotParams {
             snapshot_path: PathBuf::new(),
-            mem_file_path: PathBuf::new(),
+            mem_backend_type: Default::default(),
+            mem_backend_path: PathBuf::new(),
             enable_diff_snapshots: false,
             resume_vm: true,
         });
@@ -1601,7 +1603,8 @@ mod tests {
         check_runtime_request_err(
             VmmAction::LoadSnapshot(LoadSnapshotParams {
                 snapshot_path: PathBuf::new(),
-                mem_file_path: PathBuf::new(),
+                mem_backend_type: Default::default(),
+                mem_backend_path: PathBuf::new(),
                 enable_diff_snapshots: false,
                 resume_vm: false,
             }),
@@ -1620,7 +1623,8 @@ mod tests {
         // Load snapshot should no longer be allowed.
         let req = VmmAction::LoadSnapshot(LoadSnapshotParams {
             snapshot_path: PathBuf::new(),
-            mem_file_path: PathBuf::new(),
+            mem_backend_type: Default::default(),
+            mem_backend_path: PathBuf::new(),
             enable_diff_snapshots: false,
             resume_vm: false,
         });

--- a/src/vmm/src/vmm_config/snapshot.rs
+++ b/src/vmm/src/vmm_config/snapshot.rs
@@ -18,8 +18,26 @@ pub enum SnapshotType {
 }
 
 impl Default for SnapshotType {
-    fn default() -> SnapshotType {
+    fn default() -> Self {
         SnapshotType::Full
+    }
+}
+
+/// Specifies the type of guest memory backend:
+/// 1) A file that contains the guest memory to be loaded,
+/// 2) An UDS where a custom page-fault handler process is listening for
+///    the UFFD set up by Firecracker to handle its guest memory page faults.
+#[derive(Debug, Deserialize, PartialEq)]
+pub enum MemBackendType {
+    /// Guest memory contents will be loaded from a file.
+    File,
+    /// Guest memory will be served through UFFD by a separate process.
+    UffdOverUDS,
+}
+
+impl Default for MemBackendType {
+    fn default() -> Self {
+        MemBackendType::File
     }
 }
 
@@ -41,13 +59,15 @@ pub struct CreateSnapshotParams {
 }
 
 /// Stores the configuration that will be used for loading a snapshot.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct LoadSnapshotParams {
     /// Path to the file that contains the microVM state to be loaded.
     pub snapshot_path: PathBuf,
-    /// Path to the file that contains the guest memory to be loaded.
-    pub mem_file_path: PathBuf,
+    /// Specifies guest memory backend type.
+    pub mem_backend_type: MemBackendType,
+    /// Path to the backend used to handle the guest memory.
+    pub mem_backend_path: PathBuf,
     /// Setting this flag will enable KVM dirty page tracking and will
     /// allow taking subsequent incremental snapshots.
     #[serde(default)]

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -217,8 +217,12 @@ fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
         VERSION_MAP.clone(),
     )
     .unwrap();
-    let mem = GuestMemoryMmap::restore(memory_file.as_file(), &microvm_state.memory_state, false)
-        .unwrap();
+    let mem = GuestMemoryMmap::restore(
+        Some(memory_file.as_file()),
+        &microvm_state.memory_state,
+        false,
+    )
+    .unwrap();
 
     // Build microVM from state.
     let vmm = build_microvm_from_snapshot(

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -26,6 +26,7 @@ ENV LC_ALL=C.UTF-8
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
         binutils-dev \
+        clang \
         cmake \
         curl \
         file \
@@ -41,6 +42,9 @@ RUN apt-get update \
         libssl1.0-dev \
         lsof \
         make \
+        musl \
+        musl-dev \
+        musl-tools \
         net-tools \
         openssh-client \
         pkgconf \
@@ -91,6 +95,12 @@ RUN mkdir "$TMP_BUILD_DIR" \
         && ln -s "$CARGO_GIT_REGISTRY_DIR" "$CARGO_HOME/git" \
     && cd / \
     && rm -rf "$TMP_BUILD_DIR"
+
+# help musl-gcc find linux headers
+RUN cd /usr/include/x86_64-linux-musl \
+    && ln -s ../x86_64-linux-gnu/asm asm \
+    && ln -s ../linux linux \
+    && ln -s ../asm-generic asm-generic
 
 # Build iperf3-vsock
 RUN mkdir "$TMP_BUILD_DIR" && cd "$TMP_BUILD_DIR" \

--- a/tools/devtool
+++ b/tools/devtool
@@ -72,7 +72,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG="v31"
+DEVCTR_IMAGE_TAG="v31_uffd"
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
# Reason for This PR

Allows Firecracker customers to better manage the VMs memory.

## Description of Changes

Add new 'mem_backend_type' parameter that takes either:
 - File
 - UffdOverUDS
as valid values.
    
Rename 'mem_file_path' to 'mem_backend_path'. Interpretation of this field depends on the value of 'mem_backend_type':
 - Path to file that contains the guest memory to be loaded,
 - Path to UDS where a custom page-fault handler process is listening and expecting a Uffd to be sent by Firecracker. The Uffd is used to handle Firecracker's guest memory page faults in this separate process.

When /snapshot/load specifies memory backend type as 'UffdOverUDS', Firecracker doesn't handle the memory file itself anymore and expects an external process to handle its guest memory page faults.

To do this, anonymous memory is mmapped as guest memory while keeping the original memory regions shape. Then a Uffd is created and each guest memory range is registered with the Uffd so that any page faults won't be handled by the kernel, but will come up as events on the Uffd.

Firecracker then sends the memory ranges descriptions/mappings along with the Uffd over a UnixDomainSocket specified in 'mem_backend_path' parameter on the API call.

It is expected that on the other side there is already a process listening for incoming connections. Once Firecracker's connection is accepted, Firecracker sends the mappings and Uffd. The receiving process is from now responsible for handling any pagefaults on the Uffd.

The communication medium is a UDS, the protocol is SOCK_STREAM and the encoding is JSON.

### Example client also added

Add an example process that handles page-faults for Firecracker after a load snapshot operation.

This simple pf-handler simply populates full memory regions on page-faults belonging to those regions.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
